### PR TITLE
Feature/acc comment/update

### DIFF
--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
@@ -70,7 +70,6 @@ public class AccbookController {
 
     }
 
-
     @PutMapping("/comment/{accCommentCode}")
     public ResponseEntity<?> modifyAccComment(@RequestBody AccCommentDTO newAccCommentDTO, @PathVariable Integer accCommentCode) {
         AccComment accComment = accCommentService.modifyAccComment(accCommentCode, newAccCommentDTO);
@@ -80,5 +79,13 @@ public class AccbookController {
 
         return ResponseEntity
                 .ok(new ResponseMessage(responseMap));
+    }
+
+    @DeleteMapping("/comment/{accCommentCode}")
+    public ResponseEntity<?> removeAccComment(@PathVariable Integer accCommentCode) {
+        accCommentService.removeAccComment(accCommentCode);
+
+        return ResponseEntity
+                .noContent().build();
     }
 }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
@@ -59,9 +59,10 @@ public class AccbookController {
     }
 
     /* 가계부 댓글 관련 메소드 */
-    @PostMapping("/comment/regist")
-    public ResponseEntity<?> registAccComment(@RequestBody AccCommentDTO newAccCommentDTO) {
-        AccComment savedAccComment = accCommentService.registAccbookComment(newAccCommentDTO);
+    @PostMapping("{accbookCode}/comment")
+    public ResponseEntity<?> registAccComment(@RequestBody AccCommentDTO newAccCommentDTO,
+                                              @PathVariable Integer accbookCode) {
+        AccComment savedAccComment = accCommentService.registAccbookComment(accbookCode, newAccCommentDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accComment", savedAccComment);
@@ -70,9 +71,11 @@ public class AccbookController {
 
     }
 
-    @PutMapping("/comment/{accCommentCode}")
-    public ResponseEntity<?> modifyAccComment(@RequestBody AccCommentDTO newAccCommentDTO, @PathVariable Integer accCommentCode) {
-        AccComment accComment = accCommentService.modifyAccComment(accCommentCode, newAccCommentDTO);
+    @PutMapping("{accbookCode}/comment/{accCommentCode}")
+    public ResponseEntity<?> modifyAccComment(@RequestBody AccCommentDTO newAccCommentDTO,
+                                              @PathVariable Integer accbookCode,
+                                              @PathVariable Integer accCommentCode) {
+        AccComment accComment = accCommentService.modifyAccComment(accbookCode, accCommentCode, newAccCommentDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accComment", accComment);
@@ -81,8 +84,9 @@ public class AccbookController {
                 .ok(new ResponseMessage(responseMap));
     }
 
-    @DeleteMapping("/comment/{accCommentCode}")
-    public ResponseEntity<?> removeAccComment(@PathVariable Integer accCommentCode) {
+    @DeleteMapping("{accbookCode}/comment/{accCommentCode}")
+    public ResponseEntity<?> removeAccComment(@PathVariable Integer accbookCode,
+                                              @PathVariable Integer accCommentCode) {
         accCommentService.removeAccComment(accCommentCode);
 
         return ResponseEntity

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
@@ -29,6 +29,7 @@ public class AccbookController {
         this.accCommentService = accCommentService;
     }
 
+    /* 가계부 관련 메소드 */
     @PostMapping("/regist")
     public ResponseEntity<?> registAccbook(@RequestBody AccbookDTO newAccbook) {
         Accbook savedAccbook = accbookService.registAccbook(newAccbook);
@@ -57,6 +58,7 @@ public class AccbookController {
                 .noContent().build();
     }
 
+    /* 가계부 댓글 관련 메소드 */
     @PostMapping("/comment/regist")
     public ResponseEntity<?> registAccComment(@RequestBody AccCommentDTO newAccCommentDTO) {
         AccComment savedAccComment = accCommentService.registAccbookComment(newAccCommentDTO);
@@ -66,5 +68,17 @@ public class AccbookController {
         return ResponseEntity
                 .ok(new ResponseMessage(responseMap));
 
+    }
+
+
+    @PutMapping("/comment/{accCommentCode}")
+    public ResponseEntity<?> modifyAccComment(@RequestBody AccCommentDTO newAccCommentDTO, @PathVariable Integer accCommentCode) {
+        AccComment accComment = accCommentService.modifyAccComment(accCommentCode, newAccCommentDTO);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("accComment", accComment);
+
+        return ResponseEntity
+                .ok(new ResponseMessage(responseMap));
     }
 }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
@@ -30,7 +30,7 @@ public class AccbookController {
     }
 
     /* 가계부 관련 메소드 */
-    @PostMapping("/regist")
+    @PostMapping("")
     public ResponseEntity<?> registAccbook(@RequestBody AccbookDTO newAccbook) {
         Accbook savedAccbook = accbookService.registAccbook(newAccbook);
 
@@ -39,7 +39,7 @@ public class AccbookController {
                 .build();
     }
 
-    @PutMapping("/modify/{accbookCode}")
+    @PutMapping("/{accbookCode}")
     public ResponseEntity<?> modifyAccbook(@RequestBody AccbookDTO modifyAccbook, @PathVariable Integer accbookCode) {
         Accbook accbook = accbookService.modifyAccbook(accbookCode, modifyAccbook);
 
@@ -50,7 +50,7 @@ public class AccbookController {
                 .ok(new ResponseMessage(responseMap));
     }
 
-    @DeleteMapping("/remove/{accbookCode}")
+    @DeleteMapping("/{accbookCode}")
     public ResponseEntity<?> removeAccbook(@PathVariable Integer accbookCode) {
         accbookService.removeAccbook(accbookCode);
 

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
@@ -48,4 +48,10 @@ public class AccCommentService {
 
         return accComment;
     }
+
+    @Transactional
+    public void removeAccComment(int accCommentCode) {
+        AccComment accComment = accCommentRepository.findById(accCommentCode).orElseThrow(IllegalArgumentException::new);
+        accCommentRepository.delete(accComment);
+    }
 }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
@@ -7,6 +7,7 @@ import com.iiiiii.accountbook.accbook.command.domain.repository.AccCommentReposi
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service("AccCommentServiceCommand")
 @Slf4j
@@ -18,6 +19,8 @@ public class AccCommentService {
     public AccCommentService(AccCommentRepository accCommentRepository) {
         this.accCommentRepository = accCommentRepository;
     }
+
+    @Transactional
     public AccComment registAccbookComment(AccCommentDTO newAccCommentDTO) {
 
         AccComment accComment = new AccComment();
@@ -29,6 +32,20 @@ public class AccCommentService {
         accComment.setMemberCode(newAccCommentDTO.getMemberCode());
 
         accCommentRepository.save(accComment);
+        return accComment;
+    }
+
+    @Transactional
+    public AccComment modifyAccComment(int accCommentCode, AccCommentDTO modifyAccComment) {
+
+        AccComment accComment = accCommentRepository.findById(accCommentCode).orElseThrow(IllegalArgumentException::new);
+
+        accComment.setCreatedAt(modifyAccComment.getCreatedAt());
+        accComment.setDetail(modifyAccComment.getDetail());
+        accComment.setParentCode(modifyAccComment.getParentCode());
+        accComment.setAccbookCode(modifyAccComment.getAccbookCode());
+        accComment.setMemberCode(modifyAccComment.getMemberCode());
+
         return accComment;
     }
 }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
@@ -21,14 +21,14 @@ public class AccCommentService {
     }
 
     @Transactional
-    public AccComment registAccbookComment(AccCommentDTO newAccCommentDTO) {
+    public AccComment registAccbookComment(Integer accbookCode, AccCommentDTO newAccCommentDTO) {
 
         AccComment accComment = new AccComment();
 
+        accComment.setAccbookCode(accbookCode);
         accComment.setCreatedAt(newAccCommentDTO.getCreatedAt());
         accComment.setDetail(newAccCommentDTO.getDetail());
         accComment.setParentCode(newAccCommentDTO.getParentCode());
-        accComment.setAccbookCode(newAccCommentDTO.getAccbookCode());
         accComment.setMemberCode(newAccCommentDTO.getMemberCode());
 
         accCommentRepository.save(accComment);
@@ -36,21 +36,21 @@ public class AccCommentService {
     }
 
     @Transactional
-    public AccComment modifyAccComment(int accCommentCode, AccCommentDTO modifyAccComment) {
+    public AccComment modifyAccComment(Integer accbookCode, Integer accCommentCode, AccCommentDTO modifyAccComment) {
 
         AccComment accComment = accCommentRepository.findById(accCommentCode).orElseThrow(IllegalArgumentException::new);
 
+        accComment.setAccbookCode(accbookCode);
         accComment.setCreatedAt(modifyAccComment.getCreatedAt());
         accComment.setDetail(modifyAccComment.getDetail());
         accComment.setParentCode(modifyAccComment.getParentCode());
-        accComment.setAccbookCode(modifyAccComment.getAccbookCode());
         accComment.setMemberCode(modifyAccComment.getMemberCode());
 
         return accComment;
     }
 
     @Transactional
-    public void removeAccComment(int accCommentCode) {
+    public void removeAccComment(Integer accCommentCode) {
         AccComment accComment = accCommentRepository.findById(accCommentCode).orElseThrow(IllegalArgumentException::new);
         accCommentRepository.delete(accComment);
     }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/AccCommentDTO.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/AccCommentDTO.java
@@ -11,6 +11,5 @@ public class AccCommentDTO {
     private String createdAt;
     private String detail;
     private Integer parentCode;
-    private Integer accbookCode;
     private Integer memberCode;
 }


### PR DESCRIPTION
## :point_up: Issue Number

- #49
- #48

<br>

## :key: Key Changes

### 1. 가계부 코멘트 수정 및 삭제 기능
- 가계부 코멘트의 수정, 삭제 기능을 구현했습니다.
- 가계부 코멘트 수정, 삭제 테스트를 작성했습니다.

### 2. URL 구조 개선
- HTTP 메서드(POST, PUT, DELETE)로 동작을 구분할 수 있기 때문에 URL에서 `modify`, `regist`를 제거했습니다.
- 댓글이 어느 가계부에 달려있는지 명확히 알 수 있도록 URL에 가계부 번호를 포함시켰습니다.
  - 예시: `/accbook/{accbookCode}/comment/{accCommentCode}`

### 3. 가계부 코멘트 DTO에서 가계부 번호 제거
- 댓글 수정 시 가계부 번호를 변경할 수 없도록 DTO에서 가계부 번호 필드를 제거했습니다.

<br>

## :pray: To Reviewers

- URL 확인 부탁드립니다 :pray:
