### PR TITLE
FIX: 가계부 댓글 작성/수정 DTO 분리

### DIFF
--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/controller/AccbookController.java
@@ -1,13 +1,13 @@
 package com.iiiiii.accountbook.accbook.command.application.controller;
 
 import com.iiiiii.accountbook.accbook.command.application.service.AccCommentService;
-import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.AccCommentDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.CreateAccCommentDTO;
 import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.AccbookDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.UpdateAccCommentDTO;
 import com.iiiiii.accountbook.accbook.command.domain.aggregate.entity.AccComment;
 import com.iiiiii.accountbook.accbook.command.domain.aggregate.entity.Accbook;
 import com.iiiiii.accountbook.accbook.command.application.service.AccbookService;
 import com.iiiiii.accountbook.common.ResponseMessage;
-import com.iiiiii.accountbook.common.ResponseStatusText;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -60,7 +60,7 @@ public class AccbookController {
 
     /* 가계부 댓글 관련 메소드 */
     @PostMapping("{accbookCode}/comment")
-    public ResponseEntity<?> registAccComment(@RequestBody AccCommentDTO newAccCommentDTO,
+    public ResponseEntity<?> registAccComment(@RequestBody CreateAccCommentDTO newAccCommentDTO,
                                               @PathVariable Integer accbookCode) {
         AccComment savedAccComment = accCommentService.registAccbookComment(accbookCode, newAccCommentDTO);
 
@@ -72,10 +72,10 @@ public class AccbookController {
     }
 
     @PutMapping("{accbookCode}/comment/{accCommentCode}")
-    public ResponseEntity<?> modifyAccComment(@RequestBody AccCommentDTO newAccCommentDTO,
+    public ResponseEntity<?> modifyAccComment(@RequestBody UpdateAccCommentDTO updateAccCommentDTO,
                                               @PathVariable Integer accbookCode,
                                               @PathVariable Integer accCommentCode) {
-        AccComment accComment = accCommentService.modifyAccComment(accbookCode, accCommentCode, newAccCommentDTO);
+        AccComment accComment = accCommentService.modifyAccComment(accCommentCode, updateAccCommentDTO);
 
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accComment", accComment);

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentService.java
@@ -1,6 +1,7 @@
 package com.iiiiii.accountbook.accbook.command.application.service;
 
-import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.AccCommentDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.CreateAccCommentDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.UpdateAccCommentDTO;
 import com.iiiiii.accountbook.accbook.command.domain.aggregate.entity.AccComment;
 import com.iiiiii.accountbook.accbook.command.domain.repository.AccCommentRepository;
 
@@ -21,7 +22,7 @@ public class AccCommentService {
     }
 
     @Transactional
-    public AccComment registAccbookComment(Integer accbookCode, AccCommentDTO newAccCommentDTO) {
+    public AccComment registAccbookComment(Integer accbookCode, CreateAccCommentDTO newAccCommentDTO) {
 
         AccComment accComment = new AccComment();
 
@@ -36,15 +37,11 @@ public class AccCommentService {
     }
 
     @Transactional
-    public AccComment modifyAccComment(Integer accbookCode, Integer accCommentCode, AccCommentDTO modifyAccComment) {
+    public AccComment modifyAccComment(Integer accCommentCode, UpdateAccCommentDTO modifyAccComment) {
 
         AccComment accComment = accCommentRepository.findById(accCommentCode).orElseThrow(IllegalArgumentException::new);
 
-        accComment.setAccbookCode(accbookCode);
-        accComment.setCreatedAt(modifyAccComment.getCreatedAt());
         accComment.setDetail(modifyAccComment.getDetail());
-        accComment.setParentCode(modifyAccComment.getParentCode());
-        accComment.setMemberCode(modifyAccComment.getMemberCode());
 
         return accComment;
     }

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/CreateAccCommentDTO.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/CreateAccCommentDTO.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-public class AccCommentDTO {
+public class CreateAccCommentDTO {
     private String createdAt;
     private String detail;
     private Integer parentCode;

--- a/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/UpdateAccCommentDTO.java
+++ b/src/main/java/com/iiiiii/accountbook/accbook/command/domain/aggregate/dto/UpdateAccCommentDTO.java
@@ -1,0 +1,12 @@
+package com.iiiiii.accountbook.accbook.command.domain.aggregate.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class UpdateAccCommentDTO {
+    private String detail;
+}

--- a/src/test/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentServiceTests.java
+++ b/src/test/java/com/iiiiii/accountbook/accbook/command/application/service/AccCommentServiceTests.java
@@ -1,10 +1,10 @@
 package com.iiiiii.accountbook.accbook.command.application.service;
 
-import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.AccCommentDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.CreateAccCommentDTO;
+import com.iiiiii.accountbook.accbook.command.domain.aggregate.dto.UpdateAccCommentDTO;
 import com.iiiiii.accountbook.accbook.command.domain.aggregate.entity.AccComment;
 import com.iiiiii.accountbook.accbook.command.domain.repository.AccCommentRepository;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,7 +39,7 @@ class AccCommentServiceTests {
     void testRegistAccbookComment(Integer accbookCode, String createdAt, String detail,
                                   Integer parentCode, Integer memberCode) {
         // given
-        AccCommentDTO newAccCommentDTO = new AccCommentDTO();
+        CreateAccCommentDTO newAccCommentDTO = new CreateAccCommentDTO();
         newAccCommentDTO.setCreatedAt(createdAt);
         newAccCommentDTO.setDetail(detail);
         newAccCommentDTO.setParentCode(parentCode);
@@ -57,7 +57,7 @@ class AccCommentServiceTests {
     @ParameterizedTest
     @MethodSource("provideAccComment")
     void testModifyAccComment(Integer accbookCode, String createdAt, String detail,
-                                  Integer parentCode, Integer memberCode) {
+                              Integer parentCode, Integer memberCode) {
         // given
         AccComment initialAccComment = new AccComment();
         initialAccComment.setAccbookCode(accbookCode);
@@ -68,20 +68,14 @@ class AccCommentServiceTests {
 
         accCommentRepository.save(initialAccComment);
 
-        AccCommentDTO modifyAccCommentDTO = new AccCommentDTO();
-        modifyAccCommentDTO.setCreatedAt(createdAt);
+        UpdateAccCommentDTO modifyAccCommentDTO = new UpdateAccCommentDTO();
         modifyAccCommentDTO.setDetail(detail);
-        modifyAccCommentDTO.setParentCode(parentCode);
-        modifyAccCommentDTO.setMemberCode(memberCode);
 
         // when
-        AccComment modifiedAccComment = accCommentService.modifyAccComment(accbookCode, initialAccComment.getAccCommentCode(), modifyAccCommentDTO);
+        AccComment modifiedAccComment = accCommentService.modifyAccComment(initialAccComment.getAccCommentCode(), modifyAccCommentDTO);
 
         // then
-        assertEquals(modifiedAccComment.getCreatedAt(), modifyAccCommentDTO.getCreatedAt());
-        assertEquals(modifiedAccComment.getDetail(), modifyAccCommentDTO.getDetail());
-        assertEquals(modifiedAccComment.getParentCode(), modifyAccCommentDTO.getParentCode());
-        assertEquals(modifiedAccComment.getMemberCode(), modifyAccCommentDTO.getMemberCode());
+        assertEquals(modifyAccCommentDTO.getDetail(), modifiedAccComment.getDetail());
     }
 
     @DisplayName("가계부 코멘트 삭제 테스트")


### PR DESCRIPTION
## :point_up: Issue Number

- close #이슈번호

## :key: Key Changes

- 가계부 코멘트 작성에 필요한 정보와 수정에 필요한 정보를 구분하기 위해 작성DTO와 수정DTO를 분리했습니다.
- 생성 DTO는 댓글 작성에 필요한 생성일자/내용/상위댓글코드/멤버코드를 포함합니다.
- 수정 DTO는 수정한 코멘트 내용만 포함하도록 작성했습니다.