### PR TITLE
Feature/asset/update by accbook

### DIFF
--- a/src/main/java/com/iiiiii/accountbook/asset/command/domain/aggregate/entity/Asset.java
+++ b/src/main/java/com/iiiiii/accountbook/asset/command/domain/aggregate/entity/Asset.java
@@ -41,6 +41,7 @@ public class Asset {
 
     @PrePersist
     public void prePersist() {
-        this.isDeleted = this.isDeleted == null ? YesOrNo.N : this.isDeleted;
+        this.isDeleted = this.isDeleted == null ? YesOrNo.N : this.isDeleted;   // 삭제여부: default N
+        this.balance = this.balance == null ? 0L : this.balance;                // 현재잔액: default 0
     }
 }

--- a/src/test/java/com/iiiiii/accountbook/asset/command/service/AssetServiceTests.java
+++ b/src/test/java/com/iiiiii/accountbook/asset/command/service/AssetServiceTests.java
@@ -2,10 +2,12 @@ package com.iiiiii.accountbook.asset.command.service;
 
 import com.iiiiii.accountbook.asset.command.application.service.AssetService;
 import com.iiiiii.accountbook.asset.command.domain.aggregate.dto.AssetDTO;
+import com.iiiiii.accountbook.asset.command.domain.aggregate.entity.Asset;
 import com.iiiiii.accountbook.asset.command.domain.repository.AssetRepository;
 import com.iiiiii.accountbook.common.AssetCategory;
 import com.iiiiii.accountbook.common.YesOrNo;
 import org.junit.jupiter.api.*;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -42,5 +44,13 @@ public class AssetServiceTests {
         assetService.modifyAsset(10, modifiedAsset);
 
         assertEquals("용돈", assetRepository.findById(10).get().getName());
+    }
+
+    @DisplayName("가계부 내역 등록 시 자산 잔액 변동 테스트")
+    @Test
+    public void updateAssetByAccbook() {
+
+        assertDoesNotThrow(() -> assetService.modifyAssetByOut(9, 5000000L));
+        assertDoesNotThrow(() -> assetService.modifyAssetByIn(9, 2000000L));
     }
 }


### PR DESCRIPTION
## :point_up: Issue Number

- close #113 

<br>


## :key: Key Changes

- 가계부 지출/수입 내역 등록에 따른 자산 잔액 변동 메소드 작성
  - 지출인 경우랑 수입인 경우 나눠서 작성
- 가계부 내역 등록에 따른 자산 잔액 변동 테스트 코드 작성
- 자산 수정 메소드에 유효성 검사 조건 추가
  - 저장된 자산과 코드가 일치하는지, 삭제여부가 N인지 체크
- 자산 entity에 잔액 default 조건 추가

<br>

## :pray: To Reviewers

- 다민님! 자산 변동 메소드 작성했는데 혹시 수정사항이나 개선사항 있으면 피드백 부탁드릴게요,,😊
