### PR TITLE
자산 삭제(soft delete) 기능 추가

### DIFF
--- a/src/main/java/com/iiiiii/accountbook/asset/command/application/controller/AssetController.java
+++ b/src/main/java/com/iiiiii/accountbook/asset/command/application/controller/AssetController.java
@@ -36,4 +36,12 @@ public class AssetController {
 
         return ResponseEntity.noContent().build();
     }
+
+    /* 자산 삭제(실제로는 삭제여부, 잔액, 결제일 변경) */
+    @PutMapping("/{code}/delete")
+    public ResponseEntity<?> modifyAssetToDelete(@PathVariable Integer code) {
+        assetService.modifyAssetToDelete(code);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/iiiiii/accountbook/asset/command/application/service/AssetService.java
+++ b/src/main/java/com/iiiiii/accountbook/asset/command/application/service/AssetService.java
@@ -3,8 +3,10 @@ package com.iiiiii.accountbook.asset.command.application.service;
 import com.iiiiii.accountbook.asset.command.domain.aggregate.entity.Asset;
 import com.iiiiii.accountbook.asset.command.domain.aggregate.dto.AssetDTO;
 import com.iiiiii.accountbook.asset.command.domain.repository.AssetRepository;
+import com.iiiiii.accountbook.common.YesOrNo;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.Conditions;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +23,7 @@ public class AssetService {
     @Autowired
     public AssetService(ModelMapper modelMapper, AssetRepository assetRepository) {
         this.modelMapper = modelMapper;
+        this.modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull());   // null인 부분은 매핑 제외
         this.assetRepository = assetRepository;
     }
 
@@ -38,10 +41,66 @@ public class AssetService {
         Asset myAsset = assetRepository.findById(assetCode)
                     .orElseThrow(() -> new EntityNotFoundException("해당 코드의 자산은 존재하지 않습니다."));
 
-        if (myAsset.getCode() == modifiedAsset.getCode()) {
+        if (myAsset.getCode() == modifiedAsset.getCode() && myAsset.getIsDeleted() == YesOrNo.N) {
             assetRepository.save(modelMapper.map(modifiedAsset, Asset.class));
+        } else if (myAsset.getCode() != modifiedAsset.getCode()) {
+            throw new IllegalArgumentException("자산 코드가 일치하지 않습니다.");
         } else {
-            throw new IllegalArgumentException("수정 불가 - 자산 코드가 일치하지 않습니다.");
+            throw new IllegalArgumentException("삭제된 자산입니다.");
         }
+    }
+
+    /* 가계부 지출 내역 등록 시 자산 잔액 수정 트랜잭션 */
+    // 가계부 내역의 금액(amount)와 자산의 자산 코드(code) 사용
+    @Transactional
+    public void modifyAssetByOut(Integer assetCode, Long amount) {
+
+        Asset usedAsset = assetRepository.findById(assetCode)
+                .orElseThrow(() -> new EntityNotFoundException("해당 코드의 자산은 존재하지 않습니다."));
+
+        if (usedAsset.getBalance() >= amount && usedAsset.getIsDeleted() == YesOrNo.N) {
+            usedAsset.setBalance(usedAsset.getBalance() - amount);
+        } else if (usedAsset.getIsDeleted() != YesOrNo.N) {
+            throw new IllegalArgumentException("삭제된 자산입니다.");
+        } else {
+            throw new IllegalArgumentException("해당 자산의 현재 잔액이 입력한 금액보다 작습니다.");
+        }
+
+        assetRepository.save(usedAsset);
+    }
+
+    /* 가계부 입금 내역 등록 시 자산 잔액 수정 트랜잭션 */
+    // 가계부 내역의 금액(amount)와 자산의 자산 코드(code) 사용
+    @Transactional
+    public void modifyAssetByIn(Integer assetCode, Long amount) {
+
+        Asset increasedAsset = assetRepository.findById(assetCode)
+                .orElseThrow(() -> new EntityNotFoundException("해당 코드의 자산은 존재하지 않습니다."));
+
+        if (increasedAsset.getIsDeleted() == YesOrNo.N) {
+            increasedAsset.setBalance(increasedAsset.getBalance() + amount);
+        } else {
+            throw new IllegalArgumentException("삭제된 자산입니다.");
+        }
+
+        assetRepository.save(increasedAsset);
+    }
+
+    /* 자산 삭제 트랜잭션 */
+    // soft delete (삭제여부 -> Y, 잔액 -> 0, 결제일 -> null)
+    @Transactional
+    public void modifyAssetToDelete(Integer assetCode) {
+
+        Asset myAsset = assetRepository.findById(assetCode)
+                .orElseThrow(() -> new EntityNotFoundException("해당 코드의 자산은 존재하지 않습니다."));
+
+        if (myAsset.getIsDeleted() != YesOrNo.N)
+            throw new IllegalArgumentException("이미 삭제된 자산입니다.");
+
+        myAsset.setIsDeleted(YesOrNo.Y);
+        myAsset.setBalance(0L);
+        myAsset.setPaymentDate(null);
+
+        assetRepository.save(myAsset);
     }
 }

--- a/src/main/java/com/iiiiii/accountbook/asset/command/domain/aggregate/entity/Asset.java
+++ b/src/main/java/com/iiiiii/accountbook/asset/command/domain/aggregate/entity/Asset.java
@@ -4,6 +4,8 @@ import com.iiiiii.accountbook.common.AssetCategory;
 import com.iiiiii.accountbook.common.YesOrNo;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "asset")
@@ -41,6 +43,7 @@ public class Asset {
 
     @PrePersist
     public void prePersist() {
-        this.isDeleted = this.isDeleted == null ? YesOrNo.N : this.isDeleted;
+        this.isDeleted = this.isDeleted == null ? YesOrNo.N : this.isDeleted;   // 삭제여부: default N
+        this.balance = this.balance == null ? 0L : this.balance;                // 현재잔액: default 0
     }
 }

--- a/src/test/java/com/iiiiii/accountbook/asset/command/service/AssetServiceTests.java
+++ b/src/test/java/com/iiiiii/accountbook/asset/command/service/AssetServiceTests.java
@@ -6,6 +6,8 @@ import com.iiiiii.accountbook.asset.command.domain.repository.AssetRepository;
 import com.iiiiii.accountbook.common.AssetCategory;
 import com.iiiiii.accountbook.common.YesOrNo;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -42,5 +44,25 @@ public class AssetServiceTests {
         assetService.modifyAsset(10, modifiedAsset);
 
         assertEquals("용돈", assetRepository.findById(10).get().getName());
+    }
+
+    @DisplayName("가계부 내역 등록 시 자산 잔액 변동 테스트")
+    @Test
+    public void updateAssetByAccbook() {
+
+        assertDoesNotThrow(() -> assetService.modifyAssetByOut(9, 5000000L));
+        assertDoesNotThrow(() -> assetService.modifyAssetByIn(9, 2000000L));
+    }
+
+    @DisplayName("보유 중인 자산 삭제 시 자산의 삭제여부, 잔액, 결제일 변경 테스트")
+    @ParameterizedTest
+    @ValueSource(ints = 11)
+    public void modifyAssetToDelete(int assetCode) {
+
+        assetService.modifyAssetToDelete(assetCode);
+
+        assertEquals(YesOrNo.Y, assetRepository.findById(assetCode).get().getIsDeleted());
+        assertEquals(0L, assetRepository.findById(assetCode).get().getBalance());
+        assertNull(assetRepository.findById(assetCode).get().getPaymentDate());
     }
 }


### PR DESCRIPTION
## :point_up: Issue Number

- close #44 

<br>

## :key: Key Changes

- 자산 삭제(soft delete) 메소드 작성
  - 실제로는 데이터 삭제가 아니라 자산의 삭제여부, 잔액, 결제일이 수정된다.
- 자산 삭제(soft delete) 테스트 코드 작성
- 이전 push한 부분(가계부 내역 등록에 따른 자산 변동) 날아가서 복원...

<br>

## :pray: To Reviewers

-
