### PR TITLE
커뮤니티 댓글 삭제 기능 추가 및 Service 메소드 수정, 작성일시 타입 변경 등

### DIFF
--- a/main-server/src/main/java/com/iiiiii/accountbook/asset/command/application/service/AssetService.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/asset/command/application/service/AssetService.java
@@ -30,9 +30,10 @@ public class AssetService {
     /* 자산 등록 트랜잭션 */
     @Transactional
     public int registAsset(AssetDTO newAsset) {
-        Asset asset = assetRepository.save(modelMapper.map(newAsset, Asset.class));
+        Asset registedAsset = modelMapper.map(newAsset, Asset.class);
+        assetRepository.save(registedAsset);
 
-        return asset.getCode();
+        return registedAsset.getCode();
     }
 
     /* 자산 수정 트랜잭션 */
@@ -43,13 +44,13 @@ public class AssetService {
         Asset myAsset = assetRepository.findById(assetCode)
                     .orElseThrow(() -> new EntityNotFoundException("해당 코드의 자산은 존재하지 않습니다."));
 
-        if (myAsset.getCode() == modifiedAsset.getCode() && myAsset.getIsDeleted() == YesOrNo.N) {
-            assetRepository.save(modelMapper.map(modifiedAsset, Asset.class));
-        } else if (myAsset.getCode() != modifiedAsset.getCode()) {
+        if (myAsset.getCode() != modifiedAsset.getCode()) {
             throw new IllegalArgumentException("자산 코드가 일치하지 않습니다.");
-        } else {
+        } else if (myAsset.getIsDeleted() != YesOrNo.N) {
             throw new IllegalArgumentException("삭제된 자산입니다.");
         }
+
+        assetRepository.save(modelMapper.map(modifiedAsset, Asset.class));
     }
 
     /* 가계부 지출 내역 등록 시 자산 잔액 수정 트랜잭션 */

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/controller/CommunityController.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/controller/CommunityController.java
@@ -32,9 +32,9 @@ public class CommunityController {
     /* 게시글 등록 */
     @PostMapping("/post")
     public ResponseEntity<?> registPost(@RequestBody CommunityPostDTO newPost) {
-        communityPostService.registPost(newPost);
+        int registedCode = communityPostService.registPost(newPost);
 
-        return ResponseEntity.created(URI.create("/community/post/" + newPost.getPostCode())).build();
+        return ResponseEntity.created(URI.create("/community/post/" + registedCode)).build();
     }
 
     /* 게시글 수정 */
@@ -57,9 +57,9 @@ public class CommunityController {
     // 게시글에서 이어져야 함
     @PostMapping("/post/{postCode}")
     public ResponseEntity<?> registFile(@RequestBody CommnunityFileDTO newFile, @PathVariable Integer postCode) {
-        communityFileService.registFile(postCode, newFile);
+        int registedCode = communityFileService.registFile(postCode, newFile);
 
-        return ResponseEntity.created(URI.create("/community/post/{postCode}/" + newFile.getFileCode())).build();
+        return ResponseEntity.created(URI.create("/community/post/{postCode}/" + registedCode)).build();
     }
 
     /* 첨부파일 수정 */
@@ -86,10 +86,9 @@ public class CommunityController {
     @PostMapping("/post/{postCode}/comment")
     public ResponseEntity<?> registComment(@RequestBody CommunityCommentDTO newComment,
                                            @PathVariable Integer postCode) {
-        communityCommentService.registComment(postCode, newComment);
+        int registedCode = communityCommentService.registComment(postCode, newComment);
 
-        return ResponseEntity.created(URI.create("/community/post/{postCode}/comment/"
-                                        + newComment.getCommentCode())).build();
+        return ResponseEntity.created(URI.create("/community/post/{postCode}/comment/" + registedCode)).build();
     }
 
     /* 댓글 및 대댓글 수정 */
@@ -102,6 +101,11 @@ public class CommunityController {
         return ResponseEntity.noContent().build();
     }
 
-    /* 댓글 삭제 */
+    /* 댓글 및 대댓글 삭제 */
+    @DeleteMapping("/post/{postCode}/comment/{commentCode}")
+    public ResponseEntity<?> removeComment(@PathVariable Integer postCode, @PathVariable Integer commentCode) {
+        communityCommentService.removeComment(postCode, commentCode);
 
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityCommentService.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityCommentService.java
@@ -3,6 +3,7 @@ package com.iiiiii.accountbook.community.command.application.service;
 import com.iiiiii.accountbook.community.command.domain.aggregate.dto.CommunityCommentDTO;
 import com.iiiiii.accountbook.community.command.domain.aggregate.entity.CommunityComment;
 import com.iiiiii.accountbook.community.command.domain.repository.CommunityCommentRepository;
+import com.iiiiii.accountbook.community.command.domain.repository.CommunityPostRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.modelmapper.Conditions;
 import org.modelmapper.ModelMapper;
@@ -15,21 +16,25 @@ public class CommunityCommentService {
 
     private final ModelMapper modelMapper;
     private final CommunityCommentRepository communityCommentRepository;
+    private final CommunityPostRepository communityPostRepository;
 
     @Autowired
-    public CommunityCommentService(ModelMapper modelMapper, CommunityCommentRepository communityCommentRepository) {
+    public CommunityCommentService(ModelMapper modelMapper,
+                                   CommunityCommentRepository communityCommentRepository,
+                                   CommunityPostRepository communityPostRepository) {
         this.modelMapper = modelMapper;
         this.modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull());   // null인 부분은 매핑 제외
         this.communityCommentRepository = communityCommentRepository;
+        this.communityPostRepository = communityPostRepository;
     }
 
     /* 게시글 댓글 및 대댓글 등록 트랜잭션 */
     @Transactional
-    public void registComment(Integer postCode, CommunityCommentDTO newComment) {
+    public int registComment(Integer postCode, CommunityCommentDTO newComment) {
 
-        if (!communityCommentRepository.existsById(postCode)) {
+        if (!communityPostRepository.existsById(postCode)) {
             throw new EntityNotFoundException("존재하지 않는 게시글입니다.");
-        } else if (!postCode.equals(newComment.getCommentCode())) {
+        } else if (!postCode.equals(newComment.getCommunityPostCode())) {
             throw new IllegalArgumentException("게시글 코드가 일치하지 않습니다.");
         }
 
@@ -39,7 +44,10 @@ public class CommunityCommentService {
             }
         }
 
-        communityCommentRepository.save(modelMapper.map(newComment, CommunityComment.class));
+        CommunityComment registedComment = modelMapper.map(newComment, CommunityComment.class);
+        communityCommentRepository.save(registedComment);
+
+        return registedComment.getCommentCode();
     }
 
     /* 게시글 댓글 및 대댓글 수정 트랜잭션 */
@@ -52,10 +60,25 @@ public class CommunityCommentService {
 
         if (!comment.getCommunityPostCode().equals(postCode)) {
             throw new IllegalArgumentException("이 게시글에는 해당 댓글이 존재하지 않습니다.");
-        } else if (!comment.getCommunityPostCode().equals(modifiedComment.getCommunityPostCode())) {
-            throw new IllegalArgumentException("게시글 코드가 일치하지 않습니다.");
+        } else if (!commentCode.equals(modifiedComment.getCommentCode())) {
+            throw new IllegalArgumentException("댓글 코드가 일치하지 않습니다.");
+        }
+
+        if (modifiedComment.getParentCode() != null) {      // 대댓글인 경우
+            if (!comment.getParentCode().equals(modifiedComment.getParentCode())) {
+                throw new IllegalArgumentException("상위 댓글 코드가 일치하지 않습니다.");
+            }
         }
 
         communityCommentRepository.save(modelMapper.map(modifiedComment, CommunityComment.class));
+    }
+
+    /* 게시글 댓글 및 대댓글 삭제 트랜잭션 */
+    public void removeComment(Integer postCode, Integer commentCode) {
+
+        if (!communityPostRepository.existsById(postCode))
+            throw new EntityNotFoundException("존재하지 않는 게시글입니다.");
+
+        communityCommentRepository.deleteById(commentCode);
     }
 }

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityFileService.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityFileService.java
@@ -28,15 +28,18 @@ public class CommunityFileService {
 
     /* 게시글 첨부파일 등록 트랜잭션 */
     @Transactional
-    public void registFile(Integer postCode, CommnunityFileDTO newFile) {
+    public int registFile(Integer postCode, CommnunityFileDTO newFile) {
 
-        if (!communityPostRepository.existsById(newFile.getCommunityPostCode())) {
+        if (!communityPostRepository.existsById(postCode)) {
             throw new EntityNotFoundException("존재하지 않는 게시글입니다.");
         } else if (!postCode.equals(newFile.getCommunityPostCode())) {
             throw new IllegalArgumentException("게시글 코드가 일치하지 않습니다.");
         }
 
-        communityFileRepository.save(modelMapper.map(newFile, CommunityFile.class));
+        CommunityFile registedFile = modelMapper.map(newFile, CommunityFile.class);
+        communityFileRepository.save(registedFile);
+
+        return registedFile.getFileCode();
     }
 
     /* 게시글 첨부파일 수정 트랜잭션 */
@@ -50,8 +53,8 @@ public class CommunityFileService {
 
         if (!file.getCommunityPostCode().equals(postCode)) {
             throw new IllegalArgumentException("이 게시글에는 해당 파일이 존재하지 않습니다.");
-        } else if (!file.getCommunityPostCode().equals(modifiedFile.getCommunityPostCode())) {
-            throw new IllegalArgumentException("게시글 코드가 일치하지 않습니다.");
+        } else if (!fileCode.equals(modifiedFile.getFileCode())) {
+            throw new IllegalArgumentException("첨부파일 코드가 일치하지 않습니다.");
         }
 
         communityFileRepository.save(modelMapper.map(modifiedFile, CommunityFile.class));

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityPostService.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/application/service/CommunityPostService.java
@@ -27,8 +27,12 @@ public class CommunityPostService {
 
     /* 게시글 등록 트랜잭션 */
     @Transactional
-    public void registPost(CommunityPostDTO newPost) {
-        communityPostRepository.save(modelMapper.map(newPost, CommunityPost.class));
+    public int registPost(CommunityPostDTO newPost) {
+
+        CommunityPost registedPost = modelMapper.map(newPost, CommunityPost.class);
+        communityPostRepository.save(registedPost);
+
+        return registedPost.getPostCode();
     }
 
     /* 게시글 수정 트랜잭션 */

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/dto/CommunityCommentDTO.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/dto/CommunityCommentDTO.java
@@ -2,6 +2,8 @@ package com.iiiiii.accountbook.community.command.domain.aggregate.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -9,14 +11,14 @@ import lombok.*;
 @ToString
 public class CommunityCommentDTO {
 
-    private Integer commentCode;            // 댓글코드
-    private String commentCreatedAt;        // 댓글 작성일시
-    private String commentDetail;           // 댓글 내용
-    private Integer communityPostCode;      // 댓글이 등록된 게시글 코드
-    private int memberCode;                 // 댓글 작성 회원 코드
-    private Integer parentCode;             // 상위 댓글 코드(대댓글의 경우)
+    private Integer commentCode;                // 댓글코드
+    private LocalDateTime commentCreatedAt;     // 댓글 작성일시
+    private String commentDetail;               // 댓글 내용
+    private Integer communityPostCode;          // 댓글이 등록된 게시글 코드
+    private int memberCode;                     // 댓글 작성 회원 코드
+    private Integer parentCode;                 // 상위 댓글 코드(대댓글의 경우)
 
-    public CommunityCommentDTO(String commentCreatedAt, String commentDetail, Integer communityPostCode, int memberCode, Integer parentCode) {
+    public CommunityCommentDTO(LocalDateTime commentCreatedAt, String commentDetail, Integer communityPostCode, int memberCode, Integer parentCode) {
         this.commentCreatedAt = commentCreatedAt;
         this.commentDetail = commentDetail;
         this.communityPostCode = communityPostCode;

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/dto/CommunityPostDTO.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/dto/CommunityPostDTO.java
@@ -2,6 +2,8 @@ package com.iiiiii.accountbook.community.command.domain.aggregate.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -9,13 +11,13 @@ import lombok.*;
 @ToString
 public class CommunityPostDTO {
 
-    private int postCode;           // 게시글 코드
-    private String createdAt;       // 작성일시
-    private String title;           // 제목
-    private String detail;          // 내용
-    private int memberCode;         // 작성자
+    private int postCode;               // 게시글 코드
+    private LocalDateTime createdAt;    // 작성일시
+    private String title;               // 제목
+    private String detail;              // 내용
+    private int memberCode;             // 작성자
 
-    public CommunityPostDTO(String createdAt, String title, String detail, int memberCode) {
+    public CommunityPostDTO(LocalDateTime createdAt, String title, String detail, int memberCode) {
         this.createdAt = createdAt;
         this.title = title;
         this.detail = detail;

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/entity/CommunityComment.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/entity/CommunityComment.java
@@ -3,6 +3,8 @@ package com.iiiiii.accountbook.community.command.domain.aggregate.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "community_post_comment")
 @NoArgsConstructor
@@ -18,7 +20,7 @@ public class CommunityComment {
     private int commentCode;                    // 댓글코드
 
     @Column(name = "created_at")
-    private String commentCreatedAt;            // 댓글 작성일시
+    private LocalDateTime commentCreatedAt;     // 댓글 작성일시
 
     @Column(name = "detail")
     private String commentDetail;               // 댓글 내용

--- a/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/entity/CommunityPost.java
+++ b/main-server/src/main/java/com/iiiiii/accountbook/community/command/domain/aggregate/entity/CommunityPost.java
@@ -3,6 +3,8 @@ package com.iiiiii.accountbook.community.command.domain.aggregate.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "community_post")
 @NoArgsConstructor
@@ -15,17 +17,17 @@ public class CommunityPost {
     @Id
     @Column(name = "code")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer postCode;       // 게시글 코드
+    private Integer postCode;           // 게시글 코드
 
     @Column(name = "created_at")
-    private String createdAt;       // 작성일시
+    private LocalDateTime createdAt;    // 작성일시
 
     @Column(name = "title")
-    private String title;           // 제목
+    private String title;               // 제목
 
     @Column(name = "detail")
-    private String detail;          // 내용
+    private String detail;              // 내용
 
     @Column(name = "member_code")
-    private int memberCode;         // 작성자(회원 코드)
+    private int memberCode;             // 작성자(회원 코드)
 }

--- a/main-server/src/test/java/com/iiiiii/accountbook/community/command/application/service/CommunityServiceTests.java
+++ b/main-server/src/test/java/com/iiiiii/accountbook/community/command/application/service/CommunityServiceTests.java
@@ -1,12 +1,14 @@
 package com.iiiiii.accountbook.community.command.application.service;
 
 import com.iiiiii.accountbook.community.command.domain.aggregate.dto.CommnunityFileDTO;
+import com.iiiiii.accountbook.community.command.domain.aggregate.dto.CommunityCommentDTO;
 import com.iiiiii.accountbook.community.command.domain.aggregate.dto.CommunityPostDTO;
-import com.iiiiii.accountbook.community.command.domain.repository.CommunityPostRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,7 +22,7 @@ public class CommunityServiceTests {
     private CommunityFileService communityFileService;
 
     @Autowired
-    private CommunityPostRepository communityPostRepository;
+    private CommunityCommentService communityCommentService;
 
     @DisplayName("새로운 게시글 등록 테스트")
     @Test
@@ -28,7 +30,7 @@ public class CommunityServiceTests {
 
         CommunityPostDTO communityPost =
                 new CommunityPostDTO(
-                        "2024-02-01 10:10:00", "꿀템 발견!", "이거 보이면 꼭 사세요", 3);
+                        LocalDateTime.now(), "꿀템 발견!", "이거 보이면 꼭 사세요", 3);
 
         assertDoesNotThrow(() -> communityPostService.registPost(communityPost));
     }
@@ -38,8 +40,8 @@ public class CommunityServiceTests {
     public void modifyCommunityPost() {
 
         CommunityPostDTO modifiedPost =
-                new CommunityPostDTO(
-                        6, "2024-02-05 11:00:00", "꿀템 발견!", "단종 됐나봐요..", 3);
+                new CommunityPostDTO(6, LocalDateTime.now(),
+                        "꿀템 발견!", "단종 됐나봐요..", 3);
 
         assertDoesNotThrow(() -> communityPostService.modifyPost(6, modifiedPost));
     }
@@ -75,5 +77,33 @@ public class CommunityServiceTests {
     @Test
     public void removeCommunityFile() {
         assertDoesNotThrow(() -> communityFileService.removeFile(1, 1));
+    }
+
+    @DisplayName("게시글 댓글 등록 테스트")
+    @Test
+    public void registCommunityComment() {
+
+        CommunityCommentDTO newComment =
+                new CommunityCommentDTO(LocalDateTime.now(), "우왕 감사합니다!",
+                        2, 9, null);
+
+        assertDoesNotThrow(() -> communityCommentService.registComment(2, newComment));
+    }
+
+    @DisplayName("게시글 댓글 수정 테스트")
+    @Test
+    public void modifyCommunityComment() {
+
+        CommunityCommentDTO modifiedComment =
+                new CommunityCommentDTO(1, LocalDateTime.now(),
+                        "저도 가본 곳이네요!", 2, 9, null);
+
+        assertDoesNotThrow(() -> communityCommentService.modifyComment(2, 1, modifiedComment));
+    }
+
+    @DisplayName("게시글 댓글 삭제 테스트")
+    @Test
+    public void removeCommunityComment() {
+        assertDoesNotThrow(() -> communityCommentService.removeComment(2, 1));
     }
 }


### PR DESCRIPTION
## :point_up: Issue Number

- close #142 
- close #144 
- close #145 

<br>

## :key: Key Changes

- FEATURE: 커뮤니티 댓글 삭제 기능 추가
FEATURE: 커뮤니티 댓글 등록 / 수정 / 삭제 테스트 코드 작성
FIX: Asset Service의 등록 메소드 수정 
FIX: Community post / file / comment Service쪽 메소드 예외처리 부분 수정
FIX: Community DTO와 Entity의 작성일시 타입 String -> LocalDateTime 변경

<br>

## :pray: To Reviewers

- @yanghyeonjin 현진님, Asset Service의 자산 등록 부분 조금 수정했어요!
