### PR TITLE
Feature/accbook/add tranfer

### DIFF
--- a/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/controller/AccbookController.java
+++ b/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/controller/AccbookController.java
@@ -1,11 +1,9 @@
 package com.iiiiii.accbookserver.accbook.query.controller;
 
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookCategoryStatsDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDetailDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookTop3CategoryDTO;
+import com.iiiiii.accbookserver.accbook.query.dto.*;
 import com.iiiiii.accbookserver.accbook.query.service.AccbookService;
 import com.iiiiii.accbookserver.common.ResponseMessageGeneric;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +14,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/accbook")
+@Slf4j
 public class AccbookController {
 
     private final AccbookService accbookService;
@@ -75,6 +74,16 @@ public class AccbookController {
         AccbookDetailDTO foundAccbook = accbookService.findAccbookDetailBy(accbookCode);
         return ResponseEntity.ok(new ResponseMessageGeneric<>(foundAccbook));
     }
+
+    @GetMapping("monthly-eval/{memberCode}/{findDate}")
+    ResponseEntity<ResponseMessageGeneric<List<AccbookMonthlyEvalDTO>>> findAccbookMonthlyEvalBy(
+            @PathVariable("memberCode") Integer memberCode,
+            @PathVariable("findDate") String findDate) {
+
+        List<AccbookMonthlyEvalDTO> monthlyEval = accbookService.findAccbookMonthlyEvalBy(memberCode, findDate);
+        return ResponseEntity.ok(new ResponseMessageGeneric<>(monthlyEval));
+    }
+
 
     @GetMapping("/health")
     public String healthCheck() {

--- a/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/dto/AccbookMonthlyEvalDTO.java
+++ b/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/dto/AccbookMonthlyEvalDTO.java
@@ -1,0 +1,15 @@
+package com.iiiiii.accbookserver.accbook.query.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class AccbookMonthlyEvalDTO {
+    private String dailyDate;
+    private Integer totalOAmount;
+    private Integer totalIAmount;
+    private String evaluation;      // Good, Bad
+}

--- a/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/repository/AccbookMapper.java
+++ b/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/repository/AccbookMapper.java
@@ -1,9 +1,6 @@
 package com.iiiiii.accbookserver.accbook.query.repository;
 
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookCategoryStatsDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDetailDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookTop3CategoryDTO;
+import com.iiiiii.accbookserver.accbook.query.dto.*;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.Date;
@@ -22,4 +19,6 @@ public interface AccbookMapper {
     List<AccbookCategoryStatsDTO> selectMonthlyCategoryStats(Integer memberCode, String findDate);
 
     AccbookDetailDTO selectAccbookDetailBy(Integer accbookCode);
+
+    List<AccbookMonthlyEvalDTO> selectMonthlyEvalBy(Integer memberCode, String findDate, Integer budget);
 }

--- a/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/service/AccbookService.java
+++ b/accbook-server/src/main/java/com/iiiiii/accbookserver/accbook/query/service/AccbookService.java
@@ -1,9 +1,6 @@
 package com.iiiiii.accbookserver.accbook.query.service;
 
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookCategoryStatsDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookDetailDTO;
-import com.iiiiii.accbookserver.accbook.query.dto.AccbookTop3CategoryDTO;
+import com.iiiiii.accbookserver.accbook.query.dto.*;
 import com.iiiiii.accbookserver.accbook.query.repository.AccbookMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,4 +46,8 @@ public class AccbookService {
     }
 
 
+    public List<AccbookMonthlyEvalDTO> findAccbookMonthlyEvalBy(Integer memberCode, String findDate) {
+        Integer budget = 20000;     // TODO. feign client 통신 필요
+        return accbookMapper.selectMonthlyEvalBy(memberCode, findDate, budget);
+    }
 }

--- a/accbook-server/src/main/resources/com/iiiiii/accbookserver/accbook/query/repository/AccbookMapper.xml
+++ b/accbook-server/src/main/resources/com/iiiiii/accbookserver/accbook/query/repository/AccbookMapper.xml
@@ -57,6 +57,13 @@
                     select="selectAccCommentBy" column="CODE"/>
     </resultMap>
 
+    <resultMap id="accbookMonthlyEvalResultMap" type="com.iiiiii.accbookserver.accbook.query.dto.AccbookMonthlyEvalDTO">
+        <result property="dailyDate" column="DAILY_DATE"/>
+        <result property="totalOAmount" column="TOTAL_O_AMOUNT"/>
+        <result property="totalIAmount" column="TOTAL_I_AMOUNT"/>
+        <result property="evaluation" column="EVALUATION"/>
+    </resultMap>
+
     <!-- query -->
     <select id="selectDailyAccbookBy" resultMap="accbookResultMap">
         SELECT
@@ -185,5 +192,27 @@
                          LEFT JOIN asset D ON A.asset_code = D.code
                          LEFT JOIN asset E ON A.in_asset_code = E.code
          WHERE A.code = #{ accbookCode };
+    </select>
+
+    <select id="selectMonthlyEvalBy" resultMap="accbookMonthlyEvalResultMap">
+        WITH RECURSIVE Calendar AS (SELECT DATE(CONCAT(#{ findDate }, '-01')) As daily_date
+                                    UNION ALL
+                                    SELECT DATE_ADD(daily_date, INTERVAL 1 DAY)
+                                    FROM Calendar
+                                    WHERE DATE_ADD(daily_date, INTERVAL 1 DAY) <![CDATA[<=]]> LAST_DAY(CONCAT(#{ findDate }, '-01')))
+        SELECT
+               A.daily_date
+             , COALESCE(SUM(IF(B.finance_type = 'O', B.amount, 0)), 0) AS total_O_amount
+             , COALESCE(SUM(IF(B.finance_type = 'I', B.amount, 0)), 0) AS total_I_amount
+             , CASE
+                   WHEN COALESCE(SUM(IF(B.finance_type = 'O', B.amount, 0)), 0) <![CDATA[<=]]> #{ budget }
+                        AND A.daily_date <![CDATA[<=]]> CURDATE() THEN 'Good'
+                   WHEN COALESCE(SUM(IF(B.finance_type = 'O', B.amount, 0)), 0) <![CDATA[>]]> #{ budget }
+                        AND A.daily_date <![CDATA[<=]]> CURDATE() THEN 'Bad'
+                   ELSE null
+             END AS 'evaluation'
+         FROM Calendar A LEFT JOIN accbook B ON DATE(B.created_at) = A.daily_date AND B.member_code = #{ memberCode }
+        GROUP BY A.daily_date
+        ORDER BY A.daily_date;
     </select>
 </mapper>


### PR DESCRIPTION
## :point_up: Issue Number

- close #62
- close #56 (가계부 수정 기능에 포함)


<br>

## :key: Key Changes

- 하루 지출에 대한 평가 목록 조회 기능을 작성했습니다.
  - 검색한 달의 일자별 수입합, 지출합, 평가(Good, Bad) 리스트를 리턴합니다.
  - 월 예산/30(31)보다 지출이 작은 경우 Good, 큰 경우 Bad로 평가합니다.
  - 오늘 날짜 이후의 행에 대해서는 평가가 null로 리턴됩니다.
  - 월 예산 조회를 위해 Feign Client 통신이 필요합니다. (메서드 만들어지면 곧 수정하겠습니다😢)
 - 가계부 수정 메서드 로직이 기존 자산을 전부 복구하고 수정된 내역으로 업데이트하도록 변경되었습니다.
 - 기존 가계부 삭제 메서드에 내역 삭제 후 자산을 복구하는 부분이 빠져 있어서 수정했습니다.